### PR TITLE
[consensus] Hard limit on transaction size / decouple from block size limit

### DIFF
--- a/src/consensus/consensus.h
+++ b/src/consensus/consensus.h
@@ -16,6 +16,10 @@ static const unsigned int MAX_BLOCK_WEIGHT = 4000000;
 static const unsigned int MAX_BLOCK_BASE_SIZE = 1000000;
 /** The maximum allowed number of signature check operations in a block (network rule) */
 static const int64_t MAX_BLOCK_SIGOPS_COST = 80000;
+
+/** The maximum allowed size for a transaction, excluding witness data, in bytes */
+static const unsigned int MAX_TX_BASE_SIZE = 1000000;
+
 /** Coinbase transaction outputs can only be spent after this number of new blocks (network rule) */
 static const int COINBASE_MATURITY = 100;
 

--- a/src/test/transaction_tests.cpp
+++ b/src/test/transaction_tests.cpp
@@ -667,6 +667,45 @@ BOOST_AUTO_TEST_CASE(test_witness)
     CheckWithFlag(output1, input1, STANDARD_SCRIPT_VERIFY_FLAGS, true);
 }
 
+BOOST_AUTO_TEST_CASE(test_tx_sizelimits)
+{
+    CBasicKeyStore keystore;
+    CCoinsView coinsDummy;
+    CCoinsViewCache coins(&coinsDummy);
+    std::vector<CMutableTransaction> dummyTransactions = SetupDummyInputs(keystore, coins);
+
+    CMutableTransaction tx;
+    tx.nVersion = 1;
+    tx.vin.resize(1);
+    tx.vin[0].prevout.hash = dummyTransactions[0].GetHash();
+    tx.vin[0].prevout.n = 0;
+    tx.vout.resize(1);
+    tx.vout[0].nValue = 1;
+    tx.vout[0].scriptPubKey = CScript();
+
+    size_t sersizeTx = ::GetSerializeSize(tx, SER_NETWORK, PROTOCOL_VERSION | SERIALIZE_TRANSACTION_NO_WITNESS);
+
+    BOOST_CHECK(sersizeTx <= MAX_TX_BASE_SIZE);
+
+    CValidationState state;
+    BOOST_CHECK_MESSAGE(CheckTransaction(tx, state) && state.IsValid(), "Simple transaction should be valid.");
+
+    const size_t nTestOutputs = 125000;
+    tx.vout.resize(nTestOutputs);
+
+    for (size_t i = 0; i < nTestOutputs; i++) {
+        tx.vout[i].nValue = 1;
+        tx.vout[i].scriptPubKey = CScript();
+    }
+
+    sersizeTx = ::GetSerializeSize(tx, SER_NETWORK, PROTOCOL_VERSION | SERIALIZE_TRANSACTION_NO_WITNESS);
+
+    BOOST_CHECK(sersizeTx > MAX_TX_BASE_SIZE);
+
+    BOOST_CHECK_MESSAGE(!CheckTransaction(tx, state) || !state.IsValid(), "Large transaction should be invalid.");
+
+}
+
 BOOST_AUTO_TEST_CASE(test_IsStandard)
 {
     LOCK(cs_main);

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -497,7 +497,7 @@ bool CheckTransaction(const CTransaction& tx, CValidationState &state, bool fChe
     if (tx.vout.empty())
         return state.DoS(10, false, REJECT_INVALID, "bad-txns-vout-empty");
     // Size limits (this doesn't take the witness into account, as that hasn't been checked for malleability)
-    if (::GetSerializeSize(tx, SER_NETWORK, PROTOCOL_VERSION | SERIALIZE_TRANSACTION_NO_WITNESS) > MAX_BLOCK_BASE_SIZE)
+    if (::GetSerializeSize(tx, SER_NETWORK, PROTOCOL_VERSION | SERIALIZE_TRANSACTION_NO_WITNESS) > MAX_TX_BASE_SIZE)
         return state.DoS(100, false, REJECT_INVALID, "bad-txns-oversize");
 
     // Check for negative or overflow output values


### PR DESCRIPTION
    Establish a fixed upper limit on serialized transactions, compatible
    with existing software.
    
    Decouple transaction size limit from block size limit, by avoiding
    derivation of tx limit from block limit.