### PR TITLE
Update consensus.h

### DIFF
--- a/src/consensus/consensus.h
+++ b/src/consensus/consensus.h
@@ -13,7 +13,7 @@ static const unsigned int MAX_BLOCK_SERIALIZED_SIZE = 4000000;
 /** The maximum allowed weight for a block, see BIP 141 (network rule) */
 static const unsigned int MAX_BLOCK_WEIGHT = 4000000;
 /** The maximum allowed size for a block excluding witness data, in bytes (network rule) */
-static const unsigned int MAX_BLOCK_BASE_SIZE = 1000000;
+static const unsigned int MAX_BLOCK_BASE_SIZE = 2000000;
 /** The maximum allowed number of signature check operations in a block (network rule) */
 static const int64_t MAX_BLOCK_SIGOPS_COST = 80000;
 


### PR DESCRIPTION
increase base block to 2mb

ill leave other dev's to sort out in the validation files how to implement the old rule as 
MAX_BLOCK_BASE_SIZE / 2  where the how and when the /2 should be removed from the validation checking part of the validation files