### PR TITLE
Move up enforcement time

### DIFF
--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1852,7 +1852,7 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
     }
 
     // SEGWIT2X signalling.
-    if ( VersionBitsState(pindex->pprev, chainparams.GetConsensus(), Consensus::DEPLOYMENT_SEGWIT2X, versionbitscache) == THRESHOLD_ACTIVE &&
+    if ( VersionBitsState(pindex->pprev, chainparams.GetConsensus(), Consensus::DEPLOYMENT_SEGWIT2X, versionbitscache) == THRESHOLD_LOCKED_IN &&
          !IsWitnessLockedIn(pindex->pprev, chainparams.GetConsensus()) &&  // Segwit is not locked in
          !IsWitnessEnabled(pindex->pprev, chainparams.GetConsensus()) ) // and is not active.
     {


### PR DESCRIPTION
This allows segwit to deploy while being compatible with all versions of Bitcoin nodes.  Otherwise some existing nodes could chain split.   It's a fairly minor change.   I don't think we need to concern ourselves with miners that refuse to upgrade to /either/ core OR segwit2x.   