### PR TITLE
#29 - Mandatory block size increase validation

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -75,6 +75,7 @@ public:
         consensus.BIP34Hash = uint256S("0x000000000000024b89b42a942fe0d9fea3bb44ab7bd1b19115dd6a759c0808b8");
         consensus.BIP65Height = 388381; // 000000000000000004c2b624ed5d7756c508d90fd0da2c7c679febfa6c4735f0
         consensus.BIP66Height = 363725; // 00000000000000000379eaa19dce8c9b722d46ae6a57c2f1a988119488b50931
+        consensus.nSegWit2xHFActivationIndex = 0; // Enforces mandatory block size increase X blocks after SegWit2x activation
         consensus.powLimit = uint256S("00000000ffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
         consensus.nPowTargetTimespan = 14 * 24 * 60 * 60; // two weeks
         consensus.nPowTargetSpacing = 10 * 60;
@@ -186,6 +187,7 @@ public:
         consensus.BIP34Hash = uint256S("0x00000000fb7c0a2aeb5f1244e81921b84b7ac770004543144e10c2284f89bfd8");
         consensus.BIP65Height = 10001; // 00000000fb7c0a2aeb5f1244e81921b84b7ac770004543144e10c2284f89bfd8
         consensus.BIP66Height = 10001; // 00000000fb7c0a2aeb5f1244e81921b84b7ac770004543144e10c2284f89bfd8
+        consensus.nSegWit2xHFActivationIndex = 0; // Enforces mandatory block size increase X blocks after SegWit2x activation
         consensus.powLimit = uint256S("00000000ffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
         consensus.nPowTargetTimespan = 14 * 24 * 60 * 60; // two weeks
         consensus.nPowTargetSpacing = 10 * 60;
@@ -276,6 +278,7 @@ public:
         consensus.BIP34Hash = uint256();
         consensus.BIP65Height = 1351; // BIP65 activated on regtest (Used in rpc activation tests)
         consensus.BIP66Height = 1251; // BIP66 activated on regtest (Used in rpc activation tests)
+        consensus.nSegWit2xHFActivationIndex = 0; // Enforces mandatory block size increase X blocks after SegWit2x activation
         consensus.powLimit = uint256S("7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
         consensus.nPowTargetTimespan = 14 * 24 * 60 * 60; // two weeks
         consensus.nPowTargetSpacing = 10 * 60;

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -51,6 +51,8 @@ struct Params {
     int BIP65Height;
     /** Block height at which BIP66 becomes active */
     int BIP66Height;
+    /** Enforces mandatory block size increase X blocks after SegWit2x activation */
+    int nSegWit2xHFActivationIndex;
     /**
      * Minimum blocks including miner confirmation of the total of 2016 blocks in a retargeting period,
      * (nPowTargetTimespan / nPowTargetSpacing) which is also used for BIP9 deployments.

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1874,7 +1874,7 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
     bool fSegWitProtectBlock = (nHeight + 1 == VersionBitsTipStateSinceHeight(consensusParams, Consensus::DEPLOYMENT_SEGWIT) + consensusParams.nSegWit2xHFActivationIndex);
     // Only check if SegWit deployment is transitioning from LOCKED_IN to ACTIVE or if it's ACTIVE and we're expecting to protect this block
     if ((fSegWitInitiating || fSegWitActive) && fSegWitProtectBlock &&
-        ::GetSerializeSize(block, SER_NETWORK, PROTOCOL_VERSION | SERIALIZE_TRANSACTION_NO_WITNESS) <= MaxBlockBaseSize(nHeight, false))
+        ::GetSerializeSize(block, SER_NETWORK, PROTOCOL_VERSION | SERIALIZE_TRANSACTION_NO_WITNESS) <= MaxBlockBaseSize(nHeight + 1, false))
     {
             return state.DoS(0, error("ConnectBlock(): relayed block must meet SegWit2x minimum block size"), REJECT_INVALID, "bad-no-segwit2x");
     }


### PR DESCRIPTION
I moved the validation routines to ConnectBlock() since it didn't seem there was a good way to rerun downloaded blocks through validation again.

With this implementation the block height at which the validation happens can be modified with `consensus.nSegWit2xHFActivationIndex = 0;` in `chainparams.cpp`. Setting it to 0 requires a block size increase at the same block height that `DEPLOYMENT_SEGWIT` is activated. Setting it to 10 will require a larger block 10 blocks after `DEPLOYMENT_SEGWIT` is activated.

*Note: The DoS level for a block failing to meet the validation requirements is currently set at 0. Also the continuous integration builds fail due to `consensus.nSegWit2xHFActivationIndex` being set to 0.*

Review and QA appreciated :0)