### PR TITLE
remove not needed constant

### DIFF
--- a/src/consensus/consensus.h
+++ b/src/consensus/consensus.h
@@ -63,8 +63,6 @@ inline unsigned int MaxBlockSerSize(bool fSegwitSeasoned)
     return (MaxBlockBaseSize(fSegwitSeasoned) * 4);
 }
 
-/** The maximum allowed number of transactions per block */
-static const unsigned int MAX_BLOCK_VTX_SIZE = 1000000;
 
 /** The minimum allowed size for a transaction */
 static const unsigned int MIN_TRANSACTION_BASE_SIZE = 10;


### PR DESCRIPTION
In the comment linked below it was pointed out that this was not needed anymore, but maybe it has been overlooked: 

https://github.com/btc1/bitcoin/pull/11#discussion_r120058382