### PR TITLE
Only hardfork if Segwit2x actually activates

### DIFF
--- a/src/miner.cpp
+++ b/src/miner.cpp
@@ -169,7 +169,7 @@ std::unique_ptr<CBlockTemplate> BlockAssembler::CreateNewBlock(const CScript& sc
     // TODO: replace this with a call to main to assess validity of a mempool
     // transaction (which in most cases can be a no-op).
     fIncludeWitness = IsWitnessEnabled(pindexPrev, chainparams.GetConsensus()) && fMineWitnessTx;
-    fWitnessSeasoned = IsWitnessSeasoned(pindexPrev, chainparams.GetConsensus());
+    fWitnessSeasoned = IsSegwit2xSeasoned(pindexPrev, chainparams.GetConsensus());
 
     addPriorityTxs();
     int nPackagesSelected = 0;

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -2948,6 +2948,13 @@ bool IsSegwit2xSeasoned(const CBlockIndex* pindexPrev, const Consensus::Params& 
         return false;
     }
 
+    const int nSegwitActivationHeight = VersionBitsStateSinceHeight(pindexForkBuffer, params, Consensus::DEPLOYMENT_SEGWIT, versionbitscache);
+    const int nSegwitPeriod = VersionBitsPeriod(params, Consensus::DEPLOYMENT_SEGWIT);
+    const CBlockIndex *pindexLookback = pindexPrev->GetAncestor(nSegwitActivationHeight - nSegwitPeriod);
+    if (VersionBitsState(pindexLookback, params, Consensus::DEPLOYMENT_SEGWIT2X, versionbitscache) != THRESHOLD_ACTIVE) {
+        return false;
+    }
+
     if (fFirstBlock) {
         // Look back one more block, to detect edge
         assert(pindexForkBuffer);

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1850,7 +1850,7 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
     if (IsWitnessEnabled(pindex->pprev, chainparams.GetConsensus())) {
         flags |= SCRIPT_VERIFY_WITNESS;
         flags |= SCRIPT_VERIFY_NULLDUMMY;
-        fSegwitSeasoned = IsWitnessSeasoned(pindex->pprev, chainparams.GetConsensus());
+        fSegwitSeasoned = IsSegwit2xSeasoned(pindex->pprev, chainparams.GetConsensus());
     }
 
     // SEGWIT2X signalling.
@@ -2931,7 +2931,7 @@ bool IsWitnessEnabled(const CBlockIndex* pindexPrev, const Consensus::Params& pa
     return (VersionBitsState(pindexPrev, params, Consensus::DEPLOYMENT_SEGWIT, versionbitscache) == THRESHOLD_ACTIVE);
 }
 
-bool IsWitnessSeasoned(const CBlockIndex* pindexPrev, const Consensus::Params& params, bool * const fFirstBlock)
+bool IsSegwit2xSeasoned(const CBlockIndex* pindexPrev, const Consensus::Params& params, bool * const fFirstBlock)
 {
     AssertLockHeld(cs_main);
     assert(pindexPrev);
@@ -3100,7 +3100,7 @@ bool ContextualCheckBlock(const CBlock& block, CValidationState& state, const Co
             fHaveWitness = true;
         }
 
-        fSegwitSeasoned = IsWitnessSeasoned(pindexPrev, consensusParams, &fBIP102FirstBlock);
+        fSegwitSeasoned = IsSegwit2xSeasoned(pindexPrev, consensusParams, &fBIP102FirstBlock);
     }
 
     // Max block base size limit

--- a/src/validation.h
+++ b/src/validation.h
@@ -504,7 +504,7 @@ bool TestBlockValidity(CValidationState& state, const CChainParams& chainparams,
 bool IsWitnessEnabled(const CBlockIndex* pindexPrev, const Consensus::Params& params);
 
 /** Check whether witness has been activated for 90 days worth of blocks. */
-bool IsWitnessSeasoned(const CBlockIndex* pindexPrev, const Consensus::Params& params);
+bool IsWitnessSeasoned(const CBlockIndex* pindexPrev, const Consensus::Params& params, bool *fFirstBlock = NULL);
 
 /** When there are blocks in the active chain with missing data, rewind the chainstate and remove them from the block index */
 bool RewindBlockIndex(const CChainParams& params);

--- a/src/validation.h
+++ b/src/validation.h
@@ -504,7 +504,7 @@ bool TestBlockValidity(CValidationState& state, const CChainParams& chainparams,
 bool IsWitnessEnabled(const CBlockIndex* pindexPrev, const Consensus::Params& params);
 
 /** Check whether witness has been activated for 90 days worth of blocks. */
-bool IsWitnessSeasoned(const CBlockIndex* pindexPrev, const Consensus::Params& params, bool *fFirstBlock = NULL);
+bool IsSegwit2xSeasoned(const CBlockIndex* pindexPrev, const Consensus::Params& params, bool *fFirstBlock = NULL);
 
 /** When there are blocks in the active chain with missing data, rewind the chainstate and remove them from the block index */
 bool RewindBlockIndex(const CChainParams& params);

--- a/src/versionbits.cpp
+++ b/src/versionbits.cpp
@@ -148,7 +148,7 @@ class VersionBitsConditionChecker : public AbstractThresholdConditionChecker {
 private:
     const Consensus::DeploymentPos id;
 
-protected:
+public:
     int64_t BeginTime(const Consensus::Params& params) const { return params.vDeployments[id].nStartTime; }
     int64_t EndTime(const Consensus::Params& params) const { return params.vDeployments[id].nTimeout; }
     int Period(const Consensus::Params& params) const {
@@ -167,11 +167,15 @@ protected:
         return (((pindex->nVersion & VERSIONBITS_TOP_MASK) == VERSIONBITS_TOP_BITS) && (pindex->nVersion & Mask(params)) != 0);
     }
 
-public:
     VersionBitsConditionChecker(Consensus::DeploymentPos id_) : id(id_) {}
     uint32_t Mask(const Consensus::Params& params) const { return ((uint32_t)1) << params.vDeployments[id].bit; }
 };
 
+}
+
+int VersionBitsPeriod(const Consensus::Params& params, Consensus::DeploymentPos pos)
+{
+    return VersionBitsConditionChecker(pos).Period(params);
 }
 
 ThresholdState VersionBitsState(const CBlockIndex* pindexPrev, const Consensus::Params& params, Consensus::DeploymentPos pos, VersionBitsCache& cache)

--- a/src/versionbits.h
+++ b/src/versionbits.h
@@ -63,6 +63,7 @@ struct VersionBitsCache
     void Clear();
 };
 
+int VersionBitsPeriod(const Consensus::Params&, Consensus::DeploymentPos);
 ThresholdState VersionBitsState(const CBlockIndex* pindexPrev, const Consensus::Params& params, Consensus::DeploymentPos pos, VersionBitsCache& cache);
 int VersionBitsStateSinceHeight(const CBlockIndex* pindexPrev, const Consensus::Params& params, Consensus::DeploymentPos pos, VersionBitsCache& cache);
 uint32_t VersionBitsMask(const Consensus::Params& params, Consensus::DeploymentPos pos);


### PR DESCRIPTION
If Segwit is activated without Segwit2x, it isn't appropriate to hardfork.