### PR TITLE
Reject non SegWit2X signaling blocks.

### DIFF
--- a/qa/rpc-tests/bip91.py
+++ b/qa/rpc-tests/bip91.py
@@ -37,7 +37,7 @@ class BIP91Test(BitcoinTestFramework):
         NetworkThread().start() # Start up network handling in another thread
         self.tip = int("0x" + self.nodes[0].getbestblockhash(), 0)
         self.height = 1  # height of the next block to build
-        self.last_block_time = int(time.time())
+        self.last_block_time = int(time.time() - 10000)
 
         assert_equal(self.get_bip9_status('segwit2x')['status'], 'defined')
         assert_equal(self.get_bip9_status('segwit2x')['since'], 0)
@@ -102,26 +102,28 @@ class BIP91Test(BitcoinTestFramework):
         assert_equal(self.get_bip9_status('segwit')['status'], 'started')
         assert_equal(self.get_bip9_status('segwit')['since'], 144)
         tmpl = self.nodes[0].getblocktemplate({})
-        assert_equal(tmpl['version'], 0x10000001|0x20000002)
+        assert_equal(tmpl['version'], 0x10000001|0x20000012)
 
         # Test 5
         # bit 1 signalling becomes mandatory after bit 4 is ACTIVE
+        # bit 4 signalling becomes mandatory after bit 4 is ACTIVE
         self.generate_blocks(1, 4, 'bad-no-segwit')
         self.generate_blocks(1, 0x20000000, 'bad-no-segwit')
         self.generate_blocks(1, 0x20000010, 'bad-no-segwit')
         self.generate_blocks(1, 0x40000002, 'bad-no-segwit')
         self.generate_blocks(1, 0x60000002, 'bad-no-segwit')
         self.generate_blocks(1, 0x12, 'bad-no-segwit')
-        self.generate_blocks(35, 0x20000002)
+        self.generate_blocks(1, 0x20000002, 'bad-no-segwit2x')
         self.generate_blocks(35, 0x20000012)
-        self.generate_blocks(73, 0x20000102)
+        self.generate_blocks(35, 0x20000012)
+        self.generate_blocks(73, 0x20000112)
 
         assert_equal(self.get_bip9_status('segwit2x')['status'], 'active')
         assert_equal(self.get_bip9_status('segwit2x')['since'], 288)
         assert_equal(self.get_bip9_status('segwit')['status'], 'started')
         assert_equal(self.get_bip9_status('segwit')['since'], 144)
         tmpl = self.nodes[0].getblocktemplate({})
-        assert_equal(tmpl['version'], 0x10000001|0x20000002)
+        assert_equal(tmpl['version'], 0x10000001|0x20000012)
 
         self.generate_blocks(1, 4, 'bad-no-segwit')
         self.generate_blocks(1, 0x20000000, 'bad-no-segwit')
@@ -129,25 +131,25 @@ class BIP91Test(BitcoinTestFramework):
         self.generate_blocks(1, 0x40000002, 'bad-no-segwit')
         self.generate_blocks(1, 0x60000002, 'bad-no-segwit')
         self.generate_blocks(1, 0x12, 'bad-no-segwit')
-        self.generate_blocks(1, 0x20000002)
+        self.generate_blocks(1, 0x20000002, 'bad-no-segwit2x')
+        self.generate_blocks(1, 0x20000012)
 
         # Test 6
         # bit 1 signalling becomes optional after bit 1 locked_in
+        # bit 4 signalling is still mandatory
 
         assert_equal(self.get_bip9_status('segwit2x')['status'], 'active')
         assert_equal(self.get_bip9_status('segwit2x')['since'], 288)
         assert_equal(self.get_bip9_status('segwit')['status'], 'locked_in')
         assert_equal(self.get_bip9_status('segwit')['since'], 432)
         tmpl = self.nodes[0].getblocktemplate({})
-        assert_equal(tmpl['version'], 0x10000001|0x20000002)
+        assert_equal(tmpl['version'], 0x10000001|0x20000012)
 
-        self.generate_blocks(20, 0x20000002)
+        self.generate_blocks(1, 0x20000002, 'bad-no-segwit2x')
+        self.generate_blocks(1, 0x40000002, 'bad-no-segwit2x')
+
         self.generate_blocks(20, 0x20000012)
-        self.generate_blocks(20, 0x20000102)
-        self.generate_blocks(20, 0x20000000)
-        self.generate_blocks(20, 0x20000010)
-        self.generate_blocks(20, 0x40000002)
-        self.generate_blocks(23, 0x60000002)
+        self.generate_blocks(20, 0x20000012)
 
 
         assert_equal(self.get_bip9_status('segwit2x')['status'], 'active')
@@ -155,7 +157,7 @@ class BIP91Test(BitcoinTestFramework):
         assert_equal(self.get_bip9_status('segwit')['status'], 'locked_in')
         assert_equal(self.get_bip9_status('segwit')['since'], 432)
 
-        self.generate_blocks(1, 4)
+        self.generate_blocks(124, 0x20000010)
 
 
         assert_equal(self.get_bip9_status('segwit2x')['status'], 'active')
@@ -163,16 +165,17 @@ class BIP91Test(BitcoinTestFramework):
         assert_equal(self.get_bip9_status('segwit')['status'], 'active')
         assert_equal(self.get_bip9_status('segwit')['since'], 576)
         tmpl = self.nodes[0].getblocktemplate({})
-        assert_equal(tmpl['version'], 0x10000001|0x20000000)
+        assert_equal(tmpl['version'], 0x10000001|0x20000010)
 
-        self.generate_blocks(1, 0x20000002)
-        self.generate_blocks(1, 0x20000012)
-        self.generate_blocks(1, 0x20000102)
-        self.generate_blocks(1, 0x20000000)
+        self.generate_blocks(1, 0x20000002, 'bad-no-segwit2x')
+        self.generate_blocks(1, 0x20000102, 'bad-no-segwit2x')
+        self.generate_blocks(1, 0x20000000, 'bad-no-segwit2x')
+        self.generate_blocks(1, 0x40000002, 'bad-no-segwit2x')
+        self.generate_blocks(1, 0x60000002, 'bad-no-segwit2x')
         self.generate_blocks(1, 0x20000010)
-        self.generate_blocks(1, 0x40000002)
-        self.generate_blocks(1, 0x60000002)
-        self.generate_blocks(1, 4)
+        self.generate_blocks(1, 0x20000012)
+
+
 
     def generate_blocks(self, number, version, error = None):
         for i in range(number):
@@ -180,7 +183,10 @@ class BIP91Test(BitcoinTestFramework):
             block.nVersion = version
             block.rehash()
             block.solve()
-            assert_equal(self.nodes[0].submitblock(bytes_to_hex_str(block.serialize())), error)
+            bl = self.nodes[0].submitblock(bytes_to_hex_str(block.serialize()))
+            print( bl, error)
+            assert_equal(bl, error)
+
             if (error == None):
                 self.last_block_time += 1
                 self.tip = block.sha256

--- a/qa/rpc-tests/nulldummy.py
+++ b/qa/rpc-tests/nulldummy.py
@@ -126,7 +126,7 @@ class NULLDUMMYTest(BitcoinTestFramework):
 
     def block_submit(self, node, txs, witness = False, accept = False):
         block = create_block(self.tip, create_coinbase(self.lastblockheight + 1), self.lastblocktime + 1)
-        block.nVersion = 4
+        block.nVersion = 0x20000012
         for tx in txs:
             tx.rehash()
             block.vtx.append(tx)

--- a/qa/rpc-tests/p2p-compactblocks.py
+++ b/qa/rpc-tests/p2p-compactblocks.py
@@ -123,7 +123,7 @@ class CompactBlocksTest(BitcoinTestFramework):
 
         # Start up node0 to be a version 1, pre-segwit node.
         self.nodes = start_nodes(self.num_nodes, self.options.tmpdir, 
-                [["-debug", "-logtimemicros=1", "-bip9params=segwit:0:0", "-blockversion=536870915"], # signal segwit and csv
+                [["-debug", "-logtimemicros=1", "-bip9params=segwit:0:0", "-blockversion=536870931"], # signal segwit and csv
                  ["-debug", "-logtimemicros", "-txindex"]])
         connect_nodes(self.nodes[0], 1)
 
@@ -132,7 +132,7 @@ class CompactBlocksTest(BitcoinTestFramework):
         tip = node.getbestblockhash()
         mtp = node.getblockheader(tip)['mediantime']
         block = create_block(int(tip, 16), create_coinbase(height + 1), mtp + 1)
-        block.nVersion = 4
+        block.nVersion = 0x20000010
         if segwit:
             add_witness_commitment(block)
         block.solve()

--- a/qa/rpc-tests/segwit.py
+++ b/qa/rpc-tests/segwit.py
@@ -87,7 +87,7 @@ class SegWitTest(BitcoinTestFramework):
         self.nodes = []
         self.nodes.append(start_node(0, self.options.tmpdir, ["-logtimemicros", "-debug", "-walletprematurewitness", "-rpcserialversion=0"]))
         self.nodes.append(start_node(1, self.options.tmpdir, ["-logtimemicros", "-debug", "-blockversion=4", "-promiscuousmempoolflags=517", "-prematurewitness", "-walletprematurewitness", "-rpcserialversion=1"]))
-        self.nodes.append(start_node(2, self.options.tmpdir, ["-logtimemicros", "-debug", "-blockversion=536870915", "-promiscuousmempoolflags=517", "-prematurewitness", "-walletprematurewitness"]))
+        self.nodes.append(start_node(2, self.options.tmpdir, ["-logtimemicros", "-debug", "-blockversion=536870931", "-promiscuousmempoolflags=517", "-prematurewitness", "-walletprematurewitness"]))
         connect_nodes(self.nodes[1], 0)
         connect_nodes(self.nodes[2], 1)
         connect_nodes(self.nodes[0], 2)

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1867,7 +1867,7 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
     }
 
     if (!IsSegWit2XSignaledIfRequired(pindex->pprev, pindex->nVersion, chainparams.GetConsensus(), fSegwitSeasoned)) {
-        return state.DoS(0, error("ConnectBlock(): relayed block must signal for segwit, please upgrade"), REJECT_INVALID, "bad-no-segwit");
+        return state.DoS(0, error("ConnectBlock(): relayed block must signal for segwit2x please upgrade"), REJECT_INVALID, "bad-no-segwit2x");
     }
 
 

--- a/src/validation.h
+++ b/src/validation.h
@@ -506,6 +506,12 @@ bool IsWitnessEnabled(const CBlockIndex* pindexPrev, const Consensus::Params& pa
 /** Check whether witness has been activated for 90 days worth of blocks. */
 bool IsWitnessSeasoned(const CBlockIndex* pindexPrev, const Consensus::Params& params);
 
+/** Check if the version is correctly signaling SegWit if it needs to by BIP91 rules **/
+bool IsSegWitSignaledIfRequired(const CBlockIndex* pindexPrev, int32_t version, const Consensus::Params& params);
+
+/** Check if the version is correctly signaling SegWit2X if it needs to by BIP91 rules **/
+bool IsSegWit2XSignaledIfRequired(const CBlockIndex* pindexPrev, int32_t version, const Consensus::Params& params, bool fSegwitSeasoned);
+
 /** When there are blocks in the active chain with missing data, rewind the chainstate and remove them from the block index */
 bool RewindBlockIndex(const CChainParams& params);
 


### PR DESCRIPTION
Non SegWit2X signaling blocks are rejected between SegWit2X
activation and Segwit seasoning.

BIP91 block rejection is extracted to separate function
to implement tests.

This is proposed and discussed in #40 