### PR TITLE
Add test for fork after segwit2x activation

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -278,7 +278,7 @@ public:
         consensus.BIP34Hash = uint256();
         consensus.BIP65Height = 1351; // BIP65 activated on regtest (Used in rpc activation tests)
         consensus.BIP66Height = 1251; // BIP66 activated on regtest (Used in rpc activation tests)
-        consensus.BIP102HeightDelta = 144 * 90; // TODO: update
+        consensus.BIP102HeightDelta = 144 * 7; // TODO: update
         consensus.powLimit = uint256S("7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
         consensus.nPowTargetTimespan = 14 * 24 * 60 * 60; // two weeks
         consensus.nPowTargetSpacing = 10 * 60;
@@ -384,4 +384,3 @@ void UpdateRegtestBIP9Parameters(Consensus::DeploymentPos d, int64_t nStartTime,
 {
     regTestParams.UpdateBIP9Parameters(d, nStartTime, nTimeout);
 }
-


### PR DESCRIPTION
We have extended bip91.py test to also include the fork. To ensure a smaller block is being rejected. 

Also updated chainparams.h in regtest mode to lower the BIP102HeightDelta for faster testing.
