### PR TITLE
Remove/replace bloq seeds to improve fungibility

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -131,7 +131,6 @@ public:
         vSeeds.push_back(CDNSSeedData("seed.b-pay.net", "seed.mainnet.b-pay.net", false)); // BitPay seed
         vSeeds.push_back(CDNSSeedData("seed.ob1.io", "seed.ob1.io", false)); // OB1 seed
         vSeeds.push_back(CDNSSeedData("seed.blockchain.info", "seed.blockchain.info", false)); // blockchain.info seed
-        vSeeds.push_back(CDNSSeedData("bloqseeds.net", "bitcoin.bloqseeds.net", false)); // bloq.com seed
         vSeeds.push_back(CDNSSeedData("bitcoin.sipa.be", "seed.bitcoin.sipa.be", true)); // Pieter Wuille, only supports x1, x5, x9, and xd
         vSeeds.push_back(CDNSSeedData("bluematt.me", "dnsseed.bluematt.me", true)); // Matt Corallo, only supports x9
         vSeeds.push_back(CDNSSeedData("dashjr.org", "dnsseed.bitcoin.dashjr.org")); // Luke Dashjr
@@ -240,7 +239,6 @@ public:
         vSeeds.clear();
         // nodes with support for servicebits filtering should be at the top
         vSeeds.push_back(CDNSSeedData("testnet5.b-pay.net", "seed.testnet5.b-pay.net"));
-        vSeeds.push_back(CDNSSeedData("bloqseeds.net", "bitcoin-testnet.bloqseeds.net", false)); // bloq.com seed
 
         base58Prefixes[PUBKEY_ADDRESS] = std::vector<unsigned char>(1,111);
         base58Prefixes[SCRIPT_ADDRESS] = std::vector<unsigned char>(1,196);


### PR DESCRIPTION
Fungibility is an essential attribute of good money.  
Companies conducting **blockchain analysis should not play any trusted role within any money** protocol, since their business is breaching the privacy of the users of that money, or in other words: **their very business is built upon the notion that they are not to be trusted** by the users of the money.  
  
I propose the removal and or replacement of bloq.