### PR TITLE
[Consensus] Replace the stack-of-bools approach with scope counting to avoid quadratic runtime behaviour.

### DIFF
--- a/src/script/interpreter.cpp
+++ b/src/script/interpreter.cpp
@@ -260,7 +260,17 @@ bool EvalScript(vector<vector<unsigned char> >& stack, const CScript& script, un
     CScript::const_iterator pbegincodehash = script.begin();
     opcodetype opcode;
     valtype vchPushValue;
-    vector<bool> vfExec;
+
+    // Whether we are currently executing the opcodes.
+    bool fExec = true;
+    // Counts the number of active conditional scopes
+    int activeConditionalScopeCount = 0;
+    // Counts the number of ignored scopes (scopes that were
+    // started while fExec was false). Note that we can get away
+    // with two counts instead of a stack because a scope is only
+    //  active if its parents are active.
+    int ignoredConditionalScopeCount = 0;
+
     vector<valtype> altstack;
     set_error(serror, SCRIPT_ERR_UNKNOWN_ERROR);
     if (script.size() > MAX_SCRIPT_SIZE)
@@ -272,8 +282,6 @@ bool EvalScript(vector<vector<unsigned char> >& stack, const CScript& script, un
     {
         while (pc < pend)
         {
-            bool fExec = !count(vfExec.begin(), vfExec.end(), false);
-
             //
             // Read instruction
             //
@@ -438,7 +446,6 @@ bool EvalScript(vector<vector<unsigned char> >& stack, const CScript& script, un
                 case OP_NOTIF:
                 {
                     // <expression> if [statements] [else [statements]] endif
-                    bool fValue = false;
                     if (fExec)
                     {
                         if (stack.size() < 1)
@@ -450,28 +457,56 @@ bool EvalScript(vector<vector<unsigned char> >& stack, const CScript& script, un
                             if (vch.size() == 1 && vch[0] != 1)
                                 return set_error(serror, SCRIPT_ERR_MINIMALIF);
                         }
-                        fValue = CastToBool(vch);
+                        bool fValue = CastToBool(vch);
                         if (opcode == OP_NOTIF)
                             fValue = !fValue;
                         popstack(stack);
+                        fExec = fValue;
+                        ++activeConditionalScopeCount;
                     }
-                    vfExec.push_back(fValue);
+                    else
+                    {
+                        // None of the code in this scope will execute,
+                        // not even after OP_ELSE.
+                        ++ignoredConditionalScopeCount;
+                    }
                 }
                 break;
 
                 case OP_ELSE:
                 {
-                    if (vfExec.empty())
-                        return set_error(serror, SCRIPT_ERR_UNBALANCED_CONDITIONAL);
-                    vfExec.back() = !vfExec.back();
+                    // OP_ELSE only matters if the current scope is active.
+                    if (ignoredConditionalScopeCount == 0) {
+                        if (activeConditionalScopeCount > 0) {
+                            // We're currently inside a conditional scope,
+                            // toggle whether we're executing. Note that OP_ELSE
+                            // can happen repeatedly in a single scope, and
+                            // toggles fExec each time.
+                            fExec = !fExec;
+                        } else {
+                            // Invoked OP_ELSE while outside any conditional scope
+                            return set_error(serror, SCRIPT_ERR_UNBALANCED_CONDITIONAL);
+                        }
+                    }
                 }
                 break;
 
                 case OP_ENDIF:
                 {
-                    if (vfExec.empty())
+                    if (ignoredConditionalScopeCount > 0) {
+                        --ignoredConditionalScopeCount;
+                        // We're exiting an ignored scope, which means the
+                        // parent was not executing when the inner scope started.
+                        assert(!fExec); // fExec should have been false all along.
+                    } else if (activeConditionalScopeCount > 0) {
+                        --activeConditionalScopeCount;
+                        // We're exiting an active scope, which means the
+                        // parent was executing when the inner scope started.
+                        fExec = true;
+                    } else {
+                        // There's no scope to exit.
                         return set_error(serror, SCRIPT_ERR_UNBALANCED_CONDITIONAL);
-                    vfExec.pop_back();
+                    }
                 }
                 break;
 
@@ -1039,8 +1074,9 @@ bool EvalScript(vector<vector<unsigned char> >& stack, const CScript& script, un
         return set_error(serror, SCRIPT_ERR_UNKNOWN_ERROR);
     }
 
-    if (!vfExec.empty())
+    if (ignoredConditionalScopeCount + activeConditionalScopeCount > 0) {
         return set_error(serror, SCRIPT_ERR_UNBALANCED_CONDITIONAL);
+    }
 
     return set_success(serror);
 }


### PR DESCRIPTION
Part of the fixes for #97.

The idea behind the change is that all ignored scopes are guaranteed to
come after all non-ignored scopes. So we can replace the stack of
booleans with a pair of counts + a persistent fExec.

## Alternative solutions

Other approaches to solve the issue exist:

BTCD represents an array of tri-state (true, false, skipped) and OP_ELSE does nothing to skipped. This has maximum readability, but stores extraneous data (all trues precede the one false which precedes the skippeds, so most of the stack is redundant).

@SergioDemianLerner's original pseudocode derives the fExec flag each time, and uses the ignored count to cover the `false` conditional branch. I find it a bit confusing because ignored count == 1 is a special case with distinct behaviour.

## Testing

All tests in `src/test/test_bitcoin` pass and I've got this running on my livenet node now (it has received 2 blocks without forking FWIW).

I'm not super familiar with the testing procedure. I looked at the fuzzer, but it doesn't actually have anything that feeds into EvalScript. Open to suggestions on how best to approach this.

## Performance

I think this deserves a test in `./src/bench/bench_bitcoin` but there isn't one for it yet. This would help us measure the performance benefit in both pathological/normal cases.