### PR TITLE
Adding optin replay protection via bits 29 and 30 in tx.nVersion

### DIFF
--- a/qa/rpc-tests/fork-large-block.py
+++ b/qa/rpc-tests/fork-large-block.py
@@ -180,15 +180,24 @@ class ForkLargeBlockTest(BitcoinTestFramework):
         # Test hard fork at block 1583
         assert_equal(self.height, 584)
 
-        b = [self.nodes[0].getblockhash(n) for n in range(1, 10)]
+        b = [self.nodes[0].getblockhash(n) for n in range(1, 11)]
         txids = [self.nodes[0].getblock(h)['tx'][0] for h in b]
         spend_tx = [FromHex(CTransaction(), self.nodes[0].getrawtransaction(txid)) for txid in txids]
         for tx in spend_tx:
             tx.rehash()
-        large_tx = [self.create_tx(t, 0, 1, length=500000) for t in spend_tx]
 
-        self.generate_blocks(998, 4)
+        spend_tx_extra = spend_tx[:1]
+        spend_tx_large = spend_tx[1:]
 
+        large_tx = [self.create_tx(t, 0, 1, length=500000) for t in spend_tx_large]
+
+        noreplay_tx = self.create_tx(spend_tx_extra[0], 0, 0)
+        noreplay_tx.nVersion |= 0x20000000
+        noreplay_tx.rehash()
+
+        self.generate_blocks(997, 4)
+
+        self.generate_blocks(1, 4, txs=[noreplay_tx]) # noreplay-tx is ok
         self.generate_blocks(1, 4, "bad-blk-length", txs=[large_tx[0], large_tx[1]]) # block too large
         self.generate_blocks(1, 4, txs=[large_tx[0]]) # large txs is ok
 
@@ -207,6 +216,8 @@ class ForkLargeBlockTest(BitcoinTestFramework):
         assert_equal(self.height, 6584)
 
         self.generate_blocks(1, 4, txs=[large_tx[4], large_tx[5], large_tx[6]]) # large block ok
+        self.generate_blocks(1, 4, "bad-blk-rptx", txs=[noreplay_tx]) # reject segwit2x tx
+
 
 
     def generate_blocks(self, number, version, error = None, txs = []):

--- a/src/policy/policy.cpp
+++ b/src/policy/policy.cpp
@@ -17,7 +17,7 @@
     /**
      * Check transaction inputs to mitigate two
      * potential denial-of-service attacks:
-     * 
+     *
      * 1. scriptSigs with extra data stuffed into them,
      *    not consumed by scriptPubKey (or P2SH script)
      * 2. P2SH scripts with a crazy number of expensive
@@ -58,7 +58,7 @@ bool IsStandard(const CScript& scriptPubKey, txnouttype& whichType, const bool w
 
 bool IsStandardTx(const CTransaction& tx, std::string& reason, const bool witnessEnabled)
 {
-    if (tx.nVersion > CTransaction::MAX_STANDARD_VERSION || tx.nVersion < 1) {
+    if ((tx.nVersion & TX_VERSION_MASK) > CTransaction::MAX_STANDARD_VERSION || tx.nVersion < 1) {
         reason = "version";
         return false;
     }

--- a/src/primitives/transaction.cpp
+++ b/src/primitives/transaction.cpp
@@ -141,6 +141,12 @@ std::string CTransaction::ToString() const
     return str;
 }
 
+bool CTransaction::ReplayProtected() const
+{
+    // Reject transaction on 2x
+    return (this->nVersion & TX_VERSION_REJECT_SEGWIT2X);
+}
+
 int64_t GetTransactionWeight(const CTransaction& tx)
 {
     return ::GetSerializeSize(tx, SER_NETWORK, PROTOCOL_VERSION | SERIALIZE_TRANSACTION_NO_WITNESS) * (WITNESS_SCALE_FACTOR -1) + ::GetSerializeSize(tx, SER_NETWORK, PROTOCOL_VERSION);

--- a/src/primitives/transaction.h
+++ b/src/primitives/transaction.h
@@ -15,6 +15,11 @@ static const int SERIALIZE_TRANSACTION_NO_WITNESS = 0x40000000;
 
 static const int WITNESS_SCALE_FACTOR = 4;
 
+// Opt-in chain rejection based on bits 29 and 30 of the nVersion field (for replay protection)
+static const int TX_VERSION_MASK = 0x1fffffff;
+static const int TX_VERSION_REJECT_SEGWIT2X = 0x20000000;
+static const int TX_VERSION_REJECT_SEGWIT1X = 0x40000000;
+
 /** An outpoint - a combination of a transaction hash and an index n into its vout */
 class COutPoint
 {
@@ -390,6 +395,8 @@ public:
     }
 
     std::string ToString() const;
+
+    bool ReplayProtected() const;
 
     bool HasWitness() const
     {

--- a/src/test/transaction_tests.cpp
+++ b/src/test/transaction_tests.cpp
@@ -795,6 +795,10 @@ BOOST_AUTO_TEST_CASE(test_IsStandard)
     t.vout[0].scriptPubKey = CScript() << OP_RETURN;
     t.vout[1].scriptPubKey = CScript() << OP_RETURN;
     BOOST_CHECK(!IsStandardTx(t, reason));
+
+    t.vout.resize(1);
+    t.nVersion |= TX_VERSION_REJECT_SEGWIT2X;
+    BOOST_CHECK(IsStandardTx(t, reason));
 }
 
 BOOST_AUTO_TEST_SUITE_END()


### PR DESCRIPTION
Alternative to using scripts for opt-in replay protection.  Setting bit 29 in tx.nVersion will reject transactions on segwit2x.

Reduces blockchain bloat but does require reserving 2 bits of nVersion to signal the chain.

This was suggested by Jacob Elisoff and Sergio Lerner.  Sergio also suggested ignoring transactions not using replay protection for a brief period of time after hard fork which was omitted but could be added.