### PR TITLE
 Add opt-in transaction avoidance using well known P2SH address

### DIFF
--- a/qa/rpc-tests/fork-large-block.py
+++ b/qa/rpc-tests/fork-large-block.py
@@ -192,7 +192,7 @@ class ForkLargeBlockTest(BitcoinTestFramework):
         large_tx = [self.create_tx(t, 0, 1, length=500000) for t in spend_tx_large]
 
 		# P2SH: 3No2xBD2uteCaTNGLpFkyoin4ctgeGMRLs
-        noreplay_tx = self.create_tx(spend_tx_extra[0], 0, 0, CScript([OP_HASH160, FromHex("e77dfed888d33a87c2f48849f54dc55f4e63e7b4"), OP_EQUAL]))
+        noreplay_tx = self.create_tx(spend_tx_extra[0], 0, 0, CScript([OP_HASH160, ParseHex("e77dfed888d33a87c2f48849f54dc55f4e63e7b4"), OP_EQUAL]))
 
         self.generate_blocks(997, 4)
 

--- a/qa/rpc-tests/fork-large-block.py
+++ b/qa/rpc-tests/fork-large-block.py
@@ -191,7 +191,8 @@ class ForkLargeBlockTest(BitcoinTestFramework):
 
         large_tx = [self.create_tx(t, 0, 1, length=500000) for t in spend_tx_large]
 
-        noreplay_tx = self.create_tx(spend_tx_extra[0], 0, 0, CScript([OP_RETURN, b'RP=!>1x']))
+		# P2SH: 3No2xBD2uteCaTNGLpFkyoin4ctgeGMRLs
+        noreplay_tx = self.create_tx(spend_tx_extra[0], 0, 0, CScript([OP_HASH160, FromHex("e77dfed888d33a87c2f48849f54dc55f4e63e7b4"), OP_EQUAL]))
 
         self.generate_blocks(997, 4)
 

--- a/qa/rpc-tests/fork-large-block.py
+++ b/qa/rpc-tests/fork-large-block.py
@@ -192,7 +192,7 @@ class ForkLargeBlockTest(BitcoinTestFramework):
         large_tx = [self.create_tx(t, 0, 1, length=500000) for t in spend_tx_large]
 
 		# P2SH: 3No2xBD2uteCaTNGLpFkyoin4ctgeGMRLs
-        noreplay_tx = self.create_tx(spend_tx_extra[0], 0, 0, CScript([OP_HASH160, ParseHex("e77dfed888d33a87c2f48849f54dc55f4e63e7b4"), OP_EQUAL]))
+        noreplay_tx = self.create_tx(spend_tx_extra[0], 0, 0, CScript([OP_HASH160, hex_str_to_bytes("e77dfed888d33a87c2f48849f54dc55f4e63e7b4"), OP_EQUAL]))
 
         self.generate_blocks(997, 4)
 

--- a/qa/rpc-tests/fork-large-block.py
+++ b/qa/rpc-tests/fork-large-block.py
@@ -191,8 +191,8 @@ class ForkLargeBlockTest(BitcoinTestFramework):
 
         large_tx = [self.create_tx(t, 0, 1, length=500000) for t in spend_tx_large]
 
-		# P2SH: 3No2xBD2uteCaTNGLpFkyoin4ctgeGMRLs
-        noreplay_tx = self.create_tx(spend_tx_extra[0], 0, 0, CScript([OP_HASH160, hex_str_to_bytes("e77dfed888d33a87c2f48849f54dc55f4e63e7b4"), OP_EQUAL]))
+		# P2SH: 3Bit1xA4apyzgmFNT2k8Pvnd6zb6TnwcTi
+        noreplay_tx = self.create_tx(spend_tx_extra[0], 0, 0, CScript([OP_HASH160, hex_str_to_bytes("6e0b7d51f9f68ba28cc33a6844d41a1880c58a19"), OP_EQUAL]))
 
         self.generate_blocks(997, 4)
 

--- a/src/policy/policy.cpp
+++ b/src/policy/policy.cpp
@@ -117,6 +117,11 @@ bool IsStandardTx(const CTransaction& tx, std::string& reason, const bool witnes
         return false;
     }
 
+    if (tx.ReplayProtected()) {
+        reason = "replay-protected";
+        return false;
+    }
+
     return true;
 }
 

--- a/src/primitives/transaction.cpp
+++ b/src/primitives/transaction.cpp
@@ -143,9 +143,9 @@ std::string CTransaction::ToString() const
 
 bool CTransaction::ReplayProtected() const
 {
-    // hex("RP=!>1x") = 52503d213e3178
+	// scriptAddress: 3No2xBD2uteCaTNGLpFkyoin4ctgeGMRLs, scriptSig: 03165c4d, scriptPubKey: OP_HASH160 e77dfed888d33a87c2f48849f54dc55f4e63e7b4 OP_EQUAL
     static const CScript noReplay =
-        CScript() << OP_RETURN << ParseHex("52503d213e3178");
+        CScript() << OP_HASH160 << ParseHex("e77dfed888d33a87c2f48849f54dc55f4e63e7b4") << OP_EQUAL;
 
     for (const auto& txout : this->vout) {
         if (txout.scriptPubKey == noReplay) {

--- a/src/primitives/transaction.cpp
+++ b/src/primitives/transaction.cpp
@@ -143,9 +143,9 @@ std::string CTransaction::ToString() const
 
 bool CTransaction::ReplayProtected() const
 {
-	// scriptAddress: 3No2xBD2uteCaTNGLpFkyoin4ctgeGMRLs, scriptSig: 03165c4d, scriptPubKey: OP_HASH160 e77dfed888d33a87c2f48849f54dc55f4e63e7b4 OP_EQUAL
+	// scriptAddress: 3Bit1xA4apyzgmFNT2k8Pvnd6zb6TnwcTi, scriptSig: 04148f33be, scriptPubKey: OP_HASH160 6e0b7d51f9f68ba28cc33a6844d41a1880c58a19 OP_EQUAL
     static const CScript noReplay =
-        CScript() << OP_HASH160 << ParseHex("e77dfed888d33a87c2f48849f54dc55f4e63e7b4") << OP_EQUAL;
+        CScript() << OP_HASH160 << ParseHex("6e0b7d51f9f68ba28cc33a6844d41a1880c58a19") << OP_EQUAL;
 
     for (const auto& txout : this->vout) {
         if (txout.scriptPubKey == noReplay) {

--- a/src/primitives/transaction.cpp
+++ b/src/primitives/transaction.cpp
@@ -141,7 +141,22 @@ std::string CTransaction::ToString() const
     return str;
 }
 
+bool CTransaction::ReplayProtected() const
+{
+    // hex("RP=!>1x") = 52503d213e3178
+    static const CScript noReplay =
+        CScript() << OP_RETURN << ParseHex("52503d213e3178");
+
+    for (const auto& txout : this->vout) {
+        if (txout.scriptPubKey == noReplay) {
+            return true;
+        }
+    }
+    return false;
+}
+
 int64_t GetTransactionWeight(const CTransaction& tx)
 {
     return ::GetSerializeSize(tx, SER_NETWORK, PROTOCOL_VERSION | SERIALIZE_TRANSACTION_NO_WITNESS) * (WITNESS_SCALE_FACTOR -1) + ::GetSerializeSize(tx, SER_NETWORK, PROTOCOL_VERSION);
 }
+

--- a/src/primitives/transaction.h
+++ b/src/primitives/transaction.h
@@ -391,6 +391,8 @@ public:
 
     std::string ToString() const;
 
+    bool ReplayProtected() const;
+
     bool HasWitness() const
     {
         for (size_t i = 0; i < vin.size(); i++) {

--- a/src/test/transaction_tests.cpp
+++ b/src/test/transaction_tests.cpp
@@ -795,6 +795,15 @@ BOOST_AUTO_TEST_CASE(test_IsStandard)
     t.vout[0].scriptPubKey = CScript() << OP_RETURN;
     t.vout[1].scriptPubKey = CScript() << OP_RETURN;
     BOOST_CHECK(!IsStandardTx(t, reason));
+
+    // Replay-protected TX is non-std
+    std::string orig("RP=!>1x");
+    std::string origHex = HexStr(orig);
+    BOOST_CHECK_EQUAL(origHex, "52503d213e3178");
+
+    t.vout.resize(1);
+    t.vout[0].scriptPubKey = CScript() << OP_RETURN << ParseHex("52503d213e3178");
+    BOOST_CHECK(!IsStandardTx(t, reason));
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/test/transaction_tests.cpp
+++ b/src/test/transaction_tests.cpp
@@ -796,9 +796,9 @@ BOOST_AUTO_TEST_CASE(test_IsStandard)
     t.vout[1].scriptPubKey = CScript() << OP_RETURN;
     BOOST_CHECK(!IsStandardTx(t, reason));
 
-	// scriptAddress: 3No2xBD2uteCaTNGLpFkyoin4ctgeGMRLs, scriptSig: 03165c4d, scriptPubKey: OP_HASH160 e77dfed888d33a87c2f48849f54dc55f4e63e7b4 OP_EQUAL
+	// scriptAddress: 3Bit1xA4apyzgmFNT2k8Pvnd6zb6TnwcTi, scriptSig: 04148f33be, scriptPubKey: OP_HASH160 6e0b7d51f9f68ba28cc33a6844d41a1880c58a19 OP_EQUAL
     t.vout.resize(1);
-    t.vout[0].scriptPubKey = CScript() << OP_HASH160 << ParseHex("e77dfed888d33a87c2f48849f54dc55f4e63e7b4") << OP_EQUAL;
+    t.vout[0].scriptPubKey = CScript() << OP_HASH160 << ParseHex("6e0b7d51f9f68ba28cc33a6844d41a1880c58a19") << OP_EQUAL;
     BOOST_CHECK(!IsStandardTx(t, reason));
 }
 
@@ -806,9 +806,9 @@ BOOST_AUTO_TEST_CASE(test_ReplayProtected)
 {
     CMutableTransaction t;
 
-	// scriptAddress: 3No2xBD2uteCaTNGLpFkyoin4ctgeGMRLs, scriptSig: 03165c4d, scriptPubKey: OP_HASH160 e77dfed888d33a87c2f48849f54dc55f4e63e7b4 OP_EQUAL
+	// scriptAddress: 3Bit1xA4apyzgmFNT2k8Pvnd6zb6TnwcTi, scriptSig: 04148f33be, scriptPubKey: OP_HASH160 6e0b7d51f9f68ba28cc33a6844d41a1880c58a19 OP_EQUAL
     t.vout.resize(1);
-    t.vout[0].scriptPubKey = CScript() << OP_HASH160 << ParseHex("e77dfed888d33a87c2f48849f54dc55f4e63e7b4") << OP_EQUAL;
+    t.vout[0].scriptPubKey = CScript() << OP_HASH160 << ParseHex("6e0b7d51f9f68ba28cc33a6844d41a1880c58a19") << OP_EQUAL;
     CTransaction tx1(t);
     BOOST_CHECK(tx1.ReplayProtected());	
 

--- a/src/test/transaction_tests.cpp
+++ b/src/test/transaction_tests.cpp
@@ -796,14 +796,27 @@ BOOST_AUTO_TEST_CASE(test_IsStandard)
     t.vout[1].scriptPubKey = CScript() << OP_RETURN;
     BOOST_CHECK(!IsStandardTx(t, reason));
 
-    // Replay-protected TX is non-std
-    std::string orig("RP=!>1x");
-    std::string origHex = HexStr(orig);
-    BOOST_CHECK_EQUAL(origHex, "52503d213e3178");
-
+	// scriptAddress: 3No2xBD2uteCaTNGLpFkyoin4ctgeGMRLs, scriptSig: 03165c4d, scriptPubKey: OP_HASH160 e77dfed888d33a87c2f48849f54dc55f4e63e7b4 OP_EQUAL
     t.vout.resize(1);
-    t.vout[0].scriptPubKey = CScript() << OP_RETURN << ParseHex("52503d213e3178");
+    t.vout[0].scriptPubKey = CScript() << OP_HASH160 << ParseHex("e77dfed888d33a87c2f48849f54dc55f4e63e7b4") << OP_EQUAL;
     BOOST_CHECK(!IsStandardTx(t, reason));
+}
+
+BOOST_AUTO_TEST_CASE(test_ReplayProtected)
+{
+    CMutableTransaction t;
+
+	// scriptAddress: 3No2xBD2uteCaTNGLpFkyoin4ctgeGMRLs, scriptSig: 03165c4d, scriptPubKey: OP_HASH160 e77dfed888d33a87c2f48849f54dc55f4e63e7b4 OP_EQUAL
+    t.vout.resize(1);
+    t.vout[0].scriptPubKey = CScript() << OP_HASH160 << ParseHex("e77dfed888d33a87c2f48849f54dc55f4e63e7b4") << OP_EQUAL;
+    CTransaction tx1(t);
+    BOOST_CHECK(tx1.ReplayProtected());	
+
+	// scriptAddress: 3EZT2iZWYCpy1uXX6XtjX429TnsZ3vKvVV, scriptSig: 777777, scriptPubKey: OP_HASH160 8d2b43ea8081126af5bc392612b1471a0c4fe503 OP_EQUAL
+    t.vout.resize(1);
+    t.vout[0].scriptPubKey = CScript() << OP_HASH160 << ParseHex("8d2b43ea8081126af5bc392612b1471a0c4fe503") << OP_EQUAL;
+    CTransaction tx2(t);
+    BOOST_CHECK(!tx2.ReplayProtected());	
 }
 
 BOOST_AUTO_TEST_SUITE_END()

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -3121,6 +3121,9 @@ bool ContextualCheckBlock(const CBlock& block, CValidationState& state, const Co
     for (const auto& tx : block.vtx)
     {
         nSigOps += GetLegacySigOpCount(*tx);
+
+        if (fSegwitSeasoned && tx->ReplayProtected())
+            return state.DoS(100, false, REJECT_INVALID, "bad-blk-rptx", false, "replay-protected tx in block");
     }
     if (nSigOps * WITNESS_SCALE_FACTOR > MaxBlockSigOpsCost(fSegwitSeasoned))
         return state.DoS(100, false, REJECT_INVALID, "bad-blk-sigops", false, "out-of-bounds SigOpCount");


### PR DESCRIPTION
Based on #117 by @gavinandresen and @jgarzik.

Transactions may contain a marker output (txout) constructed as:
`OP_HASH160 6e0b7d51f9f68ba28cc33a6844d41a1880c58a19 OP_EQUAL`
This is a P2SH output with the vanity address:
`3Bit1xA4apyzgmFNT2k8Pvnd6zb6TnwcTi`.
To avoid indefinitely expanding the UTXO set, these outputs can be
spent by anyone using the intentionally concise scriptSig `03165c4d`.

1) All transactions containing this marker are considered non-standard,
and not relayed or mined by default. They may appear in a block
("valid"), but the software will not do this by default. This is
normal behavior for any valid-but-nonstandard transaction.

2) After the BIP102 hard fork point (fSegwitSeasoned), transactions
containing this marker are considered invalid. Blocks must not contain
outputs to the `3Bit1xA4apyzgmFNT2k8Pvnd6zb6TnwcTi` address.