### PR TITLE
[consensus] Add opt-in replay protection for 2x chain (using SIGHASH)

### DIFF
--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -75,7 +75,7 @@ public:
         consensus.BIP34Hash = uint256S("0x000000000000024b89b42a942fe0d9fea3bb44ab7bd1b19115dd6a759c0808b8");
         consensus.BIP65Height = 388381; // 000000000000000004c2b624ed5d7756c508d90fd0da2c7c679febfa6c4735f0
         consensus.BIP66Height = 363725; // 00000000000000000379eaa19dce8c9b722d46ae6a57c2f1a988119488b50931
-        consensus.2XHeight = 494784;
+        consensus.SW2XHeight = 494784;
         consensus.BIP102HeightDelta = 144 * 90;
         consensus.powLimit = uint256S("00000000ffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
         consensus.nPowTargetTimespan = 14 * 24 * 60 * 60; // two weeks
@@ -192,7 +192,7 @@ public:
         consensus.BIP34Hash = uint256S("0x00000000fb7c0a2aeb5f1244e81921b84b7ac770004543144e10c2284f89bfd8");
         consensus.BIP65Height = 10001; // 00000000fb7c0a2aeb5f1244e81921b84b7ac770004543144e10c2284f89bfd8
         consensus.BIP66Height = 10001; // 00000000fb7c0a2aeb5f1244e81921b84b7ac770004543144e10c2284f89bfd8
-        consensus.2XHeight = 0;
+        consensus.SW2XHeight = 0;
         consensus.BIP102HeightDelta = 144 * 90; // TODO: update re test plan
         consensus.powLimit = uint256S("00000000ffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
         consensus.nPowTargetTimespan = 14 * 24 * 60 * 60; // two weeks

--- a/src/chainparams.cpp
+++ b/src/chainparams.cpp
@@ -75,6 +75,7 @@ public:
         consensus.BIP34Hash = uint256S("0x000000000000024b89b42a942fe0d9fea3bb44ab7bd1b19115dd6a759c0808b8");
         consensus.BIP65Height = 388381; // 000000000000000004c2b624ed5d7756c508d90fd0da2c7c679febfa6c4735f0
         consensus.BIP66Height = 363725; // 00000000000000000379eaa19dce8c9b722d46ae6a57c2f1a988119488b50931
+        consensus.2XHeight = 494784;
         consensus.BIP102HeightDelta = 144 * 90;
         consensus.powLimit = uint256S("00000000ffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
         consensus.nPowTargetTimespan = 14 * 24 * 60 * 60; // two weeks
@@ -191,6 +192,7 @@ public:
         consensus.BIP34Hash = uint256S("0x00000000fb7c0a2aeb5f1244e81921b84b7ac770004543144e10c2284f89bfd8");
         consensus.BIP65Height = 10001; // 00000000fb7c0a2aeb5f1244e81921b84b7ac770004543144e10c2284f89bfd8
         consensus.BIP66Height = 10001; // 00000000fb7c0a2aeb5f1244e81921b84b7ac770004543144e10c2284f89bfd8
+        consensus.2XHeight = 0;
         consensus.BIP102HeightDelta = 144 * 90; // TODO: update re test plan
         consensus.powLimit = uint256S("00000000ffffffffffffffffffffffffffffffffffffffffffffffffffffffff");
         consensus.nPowTargetTimespan = 14 * 24 * 60 * 60; // two weeks

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -51,6 +51,8 @@ struct Params {
     int BIP65Height;
     /** Block height at which BIP66 becomes active */
     int BIP66Height;
+    /** Block height at which 2X fork happens */
+    int 2XHeight;
     /** Block height delta at which BIP102 becomes active */
     int BIP102HeightDelta;
 

--- a/src/consensus/params.h
+++ b/src/consensus/params.h
@@ -52,7 +52,7 @@ struct Params {
     /** Block height at which BIP66 becomes active */
     int BIP66Height;
     /** Block height at which 2X fork happens */
-    int 2XHeight;
+    int SW2XHeight;
     /** Block height delta at which BIP102 becomes active */
     int BIP102HeightDelta;
 

--- a/src/script/interpreter.cpp
+++ b/src/script/interpreter.cpp
@@ -208,7 +208,7 @@ bool CheckSignatureEncoding(const vector<unsigned char> &vchSig, unsigned int fl
         // serror is set
         return false;
     } else if ((flags & SCRIPT_VERIFY_STRICTENC) != 0 
-        && !IsDefinedHashtypeSignature(vchSig, (flags & SCRIPT_VERIFY_ALLOW_2X_SIGHASH != null))) {
+        && !IsDefinedHashtypeSignature(vchSig, (flags & SCRIPT_VERIFY_ALLOW_2X_SIGHASH != 0))) {
         return set_error(serror, SCRIPT_ERR_SIG_HASHTYPE);
     }
     return true;

--- a/src/script/interpreter.cpp
+++ b/src/script/interpreter.cpp
@@ -1201,6 +1201,12 @@ uint256 SignatureHash(const CScript& scriptCode, const CTransaction& txTo, unsig
             ss << txTo.vout[nIn];
             hashOutputs = ss.GetHash();
         }
+        
+        // If nHashType is set to SIGHASH_2X_REPLAY_PROTECT we require bit 8 be set to 1
+        // Requiring bit 8 to be set to 1 at all times would break backward compatibility
+        if((nHashType & 0x1f) == SIGHASH_2X_REPLAY_PROTECT) {
+            nHashType |= (1U << 8); 
+        }
 
         CHashWriter ss(SER_GETHASH, 0);
         // Version

--- a/src/script/interpreter.cpp
+++ b/src/script/interpreter.cpp
@@ -1269,7 +1269,7 @@ bool TransactionSignatureChecker::CheckSig(const vector<unsigned char>& vchSigIn
     
     // If nHashType is set to SIGHASH_2X_REPLAY_PROTECT we require bit 8 be set to 1
     // Requiring bit 8 to be set to 1 at all times would break backward compatibility
-    if (replayProtection && (nHashType & 0x1f) == SIGHASH_2X_REPLAY_PROTECT)
+    if (fReplayProtection && (nHashType & 0x1f) == SIGHASH_2X_REPLAY_PROTECT)
         nHashType |= (1U << 8); 
 
     uint256 sighash = SignatureHash(scriptCode, *txTo, nIn, nHashType, amount, sigversion, this->txdata);

--- a/src/script/interpreter.cpp
+++ b/src/script/interpreter.cpp
@@ -183,7 +183,7 @@ bool static IsLowDERSignature(const valtype &vchSig, ScriptError* serror) {
     return true;
 }
 
-bool static IsDefinedHashtypeSignature(const valtype &vchSig, const boolean allowReplay) {
+bool static IsDefinedHashtypeSignature(const valtype &vchSig, const bool allowReplay) {
     if (vchSig.size() == 0) {
         return false;
     }

--- a/src/script/interpreter.cpp
+++ b/src/script/interpreter.cpp
@@ -208,7 +208,7 @@ bool CheckSignatureEncoding(const vector<unsigned char> &vchSig, unsigned int fl
         // serror is set
         return false;
     } else if ((flags & SCRIPT_VERIFY_STRICTENC) != 0 
-        && !IsDefinedHashtypeSignature(vchSig, (flags & SCRIPT_VERIFY_ALLOW_2X_SIGHASH != 0))) {
+        && !IsDefinedHashtypeSignature(vchSig, ((flags & SCRIPT_VERIFY_ALLOW_2X_SIGHASH) != 0))) {
         return set_error(serror, SCRIPT_ERR_SIG_HASHTYPE);
     }
     return true;

--- a/src/script/interpreter.h
+++ b/src/script/interpreter.h
@@ -132,7 +132,7 @@ uint256 SignatureHash(const CScript &scriptCode, const CTransaction& txTo, unsig
 class BaseSignatureChecker
 {
 public:
-    virtual bool CheckSig(const std::vector<unsigned char>& scriptSig, const std::vector<unsigned char>& vchPubKey, const CScript& scriptCode, SigVersion sigversion) const
+    virtual bool CheckSig(const std::vector<unsigned char>& scriptSig, const std::vector<unsigned char>& vchPubKey, const CScript& scriptCode, SigVersion sigversion, bool fReplayProtection) const
     {
         return false;
     }
@@ -164,7 +164,7 @@ protected:
 public:
     TransactionSignatureChecker(const CTransaction* txToIn, unsigned int nInIn, const CAmount& amountIn) : txTo(txToIn), nIn(nInIn), amount(amountIn), txdata(NULL) {}
     TransactionSignatureChecker(const CTransaction* txToIn, unsigned int nInIn, const CAmount& amountIn, const PrecomputedTransactionData& txdataIn) : txTo(txToIn), nIn(nInIn), amount(amountIn), txdata(&txdataIn) {}
-    bool CheckSig(const std::vector<unsigned char>& scriptSig, const std::vector<unsigned char>& vchPubKey, const CScript& scriptCode, SigVersion sigversion) const;
+    bool CheckSig(const std::vector<unsigned char>& scriptSig, const std::vector<unsigned char>& vchPubKey, const CScript& scriptCode, SigVersion sigversion, bool fReplayProtection) const;
     bool CheckLockTime(const CScriptNum& nLockTime) const;
     bool CheckSequence(const CScriptNum& nSequence) const;
 };

--- a/src/script/interpreter.h
+++ b/src/script/interpreter.h
@@ -25,6 +25,7 @@ enum
     SIGHASH_NONE = 2,
     SIGHASH_SINGLE = 3,
     SIGHASH_ANYONECANPAY = 0x80,
+    SIGHASH_2X_REPLAY_PROTECT = 4,
 };
 
 /** Script verification flags */
@@ -106,6 +107,9 @@ enum
     // Public keys in segregated witness scripts must be compressed
     //
     SCRIPT_VERIFY_WITNESS_PUBKEYTYPE = (1U << 15),
+
+    // After the 2X fork date, we allow a special SIGHASH 
+    SCRIPT_VERIFY_ALLOW_2X_SIGHASH = (1U << 16),
 };
 
 bool CheckSignatureEncoding(const std::vector<unsigned char> &vchSig, unsigned int flags, ScriptError* serror);

--- a/src/script/sign.cpp
+++ b/src/script/sign.cpp
@@ -258,7 +258,7 @@ static vector<valtype> CombineMultisig(const CScript& scriptPubKey, const BaseSi
             if (sigs.count(pubkey))
                 continue; // Already got a sig for this pubkey
 
-            if (checker.CheckSig(sig, pubkey, scriptPubKey, sigversion))
+            if (checker.CheckSig(sig, pubkey, scriptPubKey, sigversion, true))
             {
                 sigs[pubkey] = sig;
                 break;
@@ -396,7 +396,7 @@ class DummySignatureChecker : public BaseSignatureChecker
 public:
     DummySignatureChecker() {}
 
-    bool CheckSig(const std::vector<unsigned char>& scriptSig, const std::vector<unsigned char>& vchPubKey, const CScript& scriptCode, SigVersion sigversion) const
+    bool CheckSig(const std::vector<unsigned char>& scriptSig, const std::vector<unsigned char>& vchPubKey, const CScript& scriptCode, SigVersion sigversion, bool fReplayProtection) const
     {
         return true;
     }

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -955,7 +955,7 @@ bool AcceptToMemoryPoolWorker(CTxMemPool& pool, CValidationState& state, const C
         //     until actual fork. Eventually these transactions would drop out of
         //     the mempool. 
         const int nBlockHeight = chainActive.Height();
-        if (nBlockHeight >= Params().SW2XHeight) {
+        if (nBlockHeight >= Params().GetConsensus().SW2XHeight) {
             scriptVerifyFlags |= SCRIPT_VERIFY_ALLOW_2X_SIGHASH;
         }
 

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -956,7 +956,7 @@ bool AcceptToMemoryPoolWorker(CTxMemPool& pool, CValidationState& state, const C
         //     the mempool. 
         const int nBlockHeight = chainActive.Height();
         if (nBlockHeight >= Params().SW2XHeight) {
-            flags |= SCRIPT_VERIFY_ALLOW_2X_SIGHASH;
+            scriptVerifyFlags |= SCRIPT_VERIFY_ALLOW_2X_SIGHASH;
         }
 
         // Check against previous transactions

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1853,7 +1853,7 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
         fSegwitSeasoned = IsWitnessSeasoned(pindex->pprev, chainparams.GetConsensus());
     }
     
-    if (pindex->nHeight >= chainparams.GetConsensus().BIP66Height) {
+    if (pindex->nHeight >= chainparams.GetConsensus().SW2XHeight) {
         flags |= SCRIPT_VERIFY_ALLOW_2X_SIGHASH;
     }
 

--- a/src/validation.cpp
+++ b/src/validation.cpp
@@ -1852,6 +1852,10 @@ bool ConnectBlock(const CBlock& block, CValidationState& state, CBlockIndex* pin
         flags |= SCRIPT_VERIFY_NULLDUMMY;
         fSegwitSeasoned = IsWitnessSeasoned(pindex->pprev, chainparams.GetConsensus());
     }
+    
+    if (pindex->nHeight >= chainparams.GetConsensus().BIP66Height) {
+        flags |= SCRIPT_VERIFY_ALLOW_2X_SIGHASH;
+    }
 
     // SEGWIT2X signalling.
     if (VersionBitsState(pindex->pprev, chainparams.GetConsensus(), Consensus::DEPLOYMENT_SEGWIT2X, versionbitscache) == THRESHOLD_ACTIVE &&


### PR DESCRIPTION
This is a WIP branch. 

The initial idea is to take something that is currently forbidden in bitcoin, but only checked by full nodes, and allow it. By doing this, we allow wallets to create transactions that are only valid on this chain.

For this PR I've chosen a new SIGHASH id, similar to the approach taken by Bitcoin Cash (except that we don't *require* this SIGHASH, we barely allow it). We need to assess whether there are any light wallets that do actually do any sanity checks on the SIGHASH field. Unless there are, this change should satisfy the condition, of _not breaking consumer wallets_. 

I am aware that this change adds some technical debt. Ideally we also add a sunset clause, although it would need to have a large time horizon (2 years+).

There are other approaches, as described in https://github.com/btc1/bitcoin/issues/34#issuecomment-324431253 - they might have other merits or downsides, I am open for discussion.

Tests haven't been written/fixed yet, as I first want to see if this approach has consensus.