### PR TITLE
Explicitly skip broken tests so that the test runner doesn't complain…

### DIFF
--- a/test/functional/p2p-compactblocks.py
+++ b/test/functional/p2p-compactblocks.py
@@ -9,7 +9,7 @@ Version 2 compact blocks are post-segwit (wtxids)
 """
 
 from test_framework.mininode import *
-from test_framework.test_framework import BitcoinTestFramework
+from test_framework.test_framework import BitcoinTestFramework, SkipTest
 from test_framework.util import *
 from test_framework.blocktools import create_block, create_coinbase, add_witness_commitment
 from test_framework.script import CScript, OP_TRUE
@@ -800,6 +800,8 @@ class CompactBlocksTest(BitcoinTestFramework):
         assert_equal(int(node.getbestblockhash(), 16), block.sha256)
 
     def run_test(self):
+        raise SkipTest("This test is currently broken")
+
         # Setup the p2p connections and start up the network thread.
         self.test_node = TestNode()
         self.segwit_node = TestNode()

--- a/test/functional/p2p-leaktests.py
+++ b/test/functional/p2p-leaktests.py
@@ -15,7 +15,7 @@ and don't receive a VERACK. Unsupported service bits are currently 1 << 5 and
 1 << 7 (until August 1st 2018)."""
 
 from test_framework.mininode import *
-from test_framework.test_framework import BitcoinTestFramework
+from test_framework.test_framework import BitcoinTestFramework, SkipTest
 from test_framework.util import *
 
 banscore = 10
@@ -98,6 +98,8 @@ class P2PLeakTest(BitcoinTestFramework):
         self.extra_args = [['-banscore='+str(banscore)]]
 
     def run_test(self):
+        raise SkipTest("This test is currently broken")
+
         no_version_bannode = CNodeNoVersionBan()
         no_version_idlenode = CNodeNoVersionIdle()
         no_verack_idlenode = CNodeNoVerackIdle()

--- a/test/functional/test_runner.py
+++ b/test/functional/test_runner.py
@@ -55,11 +55,11 @@ BASE_SCRIPTS= [
     # Scripts that are run by the travis build process.
     # Longest test should go first, to favor running tests in parallel
     'wallet-hd.py',
-# to-fix?    'walletbackup.py',
+    'walletbackup.py',
     # vv Tests less than 5m vv
     'p2p-fullblocktest.py',
     'fundrawtransaction.py',
-# to-fix    'p2p-compactblocks.py',
+    'p2p-compactblocks.py',
     'segwit.py',
     # vv Tests less than 2m vv
     'wallet.py',
@@ -114,7 +114,7 @@ BASE_SCRIPTS= [
     'bumpfee.py',
     'rpcnamedargs.py',
     'listsinceblock.py',
-# to-fix    'p2p-leaktests.py',
+    'p2p-leaktests.py',
     'wallet-encryption.py',
     'bipdersig-p2p.py',
     'bip65-cltv-p2p.py',


### PR DESCRIPTION
… about them not being run at all.

Also reenabled walletbackup.py since it works locally.

If I did everything correctly we should see a passing Travis build.

This is step 1 towards fixing and re-enabling these 2 tests.