### PR TITLE
Update miner default block size settings

### DIFF
--- a/src/policy/policy.h
+++ b/src/policy/policy.h
@@ -17,9 +17,9 @@ class CCoinsViewCache;
 class CTxOut;
 
 /** Default for -blockmaxsize, which controls the maximum size of block the mining code will create **/
-static const unsigned int DEFAULT_BLOCK_MAX_SIZE = 750000;
+static const unsigned int DEFAULT_BLOCK_MAX_SIZE = 2000000;
 /** Default for -blockmaxweight, which controls the range of block weights the mining code will create **/
-static const unsigned int DEFAULT_BLOCK_MAX_WEIGHT = 3000000;
+static const unsigned int DEFAULT_BLOCK_MAX_WEIGHT = 8000000;
 /** Default for -blockmintxfee, which sets the minimum feerate for a transaction in blocks created by mining code **/
 static const unsigned int DEFAULT_BLOCK_MIN_TX_FEE = 1000;
 /** The maximum weight for transactions we're willing to relay/mine */

--- a/src/test/miner_tests.cpp
+++ b/src/test/miner_tests.cpp
@@ -30,11 +30,6 @@ static CFeeRate blockMinFeeRate = CFeeRate(DEFAULT_BLOCK_MIN_TX_FEE);
 
 static BlockAssembler AssemblerForTest(const CChainParams& params) {
     BlockAssembler::Options options;
-
-#warning hack
-    //options.nBlockMaxWeight = MAX_BLOCK_WEIGHT;
-    options.nBlockMaxSize = MAX_BLOCK_SERIALIZED_SIZE;
-    options.blockMinFeeRate = blockMinFeeRate;
     return BlockAssembler(params, options);
 }
 


### PR DESCRIPTION
- Updating default miner block size settings.
- Block size/weight sanity checks moved to CreateNewBlock to handle case of HF change.