### PR TITLE
[Policy] Simple opt-in replay protection (1 LOC)

### DIFF
--- a/src/policy/policy.cpp
+++ b/src/policy/policy.cpp
@@ -111,8 +111,8 @@ bool IsStandardTx(const CTransaction& tx, std::string& reason, const bool witnes
         }
     }
 
-    // only one OP_RETURN txout is permitted
-    if (nDataOut > 1) {
+    // only two OP_RETURN txouts are permitted
+    if (nDataOut > 2) {
         reason = "multi-op-return";
         return false;
     }


### PR DESCRIPTION
This relaxes the `IsStandardTx()` rules for the chain and allows the use of a second `OP_RETURN` output. 

By default, transactions containing 2 `OP_RETURN` will now only be relayed and mined on the segwit2x chain. Splitting your coins for Users/Exchanges/Wallets becomes very easy and reasonably safe. It requires only addition of 2 `OP_RETURN` outputs (both can be 0 bytes long) to the first transaction(s) which spends exclusively `TxIns` originate from pre-fork block heights. No additional UTXO burden for either chain. No uncertain nLocktime magic. And later on, policy can be reenforced to only allow second OP_RETURN when spending pre-fork coins for the first time.

Since this is neither an additional soft- or hard fork but a relay policy change it doesn't prevent miners from including them on the legacy chain but makes it considerably harder while making wallet implementation a breeze.

It's not intended for merging yet but for discussing this simple workaround.